### PR TITLE
Fix file import example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ english.object()
 You probably don't want to load all languages. So I suggest you to load specific files.
 
 ```js
-var englishCountries = require('localized-countries')(require('localized-countries/data/en'))
+var englishCountries = require('localized-countries')(require('localized-countries/data/en.json'))
 englishCountries.get('US') // returns 'United States'
 ```
 


### PR DESCRIPTION
Since there is no file called "en" within the data directory, the current example fails to load and webpack compilation fails.
